### PR TITLE
add correct logic for field availability and related className

### DIFF
--- a/src/components/Column/Column.jsx
+++ b/src/components/Column/Column.jsx
@@ -295,7 +295,7 @@ const Column = ({ column, isRandomColumn = false }) => {
             key={item[0]}
             className={`
               ${classes.field}
-              ${(!item[1].isChecked && item[1].isAvailable && item[1].isPreviousChecked) ? `${classes.available}` : null}`
+              ${(item[1].isAvailable && !item[1].isChecked) ? `${classes.available}` : null}`
             }
             onClick={() => fieldClickHandler(item)}
           >


### PR DESCRIPTION
Closes #17 

This PR fixes bug of field availability calculation.

A field is available only if it is in order, the previous field is checked and it itself is not checked.

Player cannot click on a checked field, nor on an unavailable field.